### PR TITLE
Get redux state before first render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ export const Provider = ({ store, children }) => (
 );
 
 export const useRedux = () => {
-	const [state, setState] = useState({});
 	const context = useContext(ReduxContext);
+	const [state, setState] = useState(context.getState());
 
 	function handleChange() {
 		setState(context.getState());


### PR DESCRIPTION
First, thanks for creating the library and saving us all a lot of hard work!

I've noticed that the first render of a component receives an empty object, rather than the current Redux store state.

I've tried fixing this locally by initialising the `useState` hook with the result of calling `context.getState()` directly, rather than to an empty object.

So far it doesn't seem to have caused any issues! Please consider merging this PR, if it is helpful to others.